### PR TITLE
Add Player movement

### DIFF
--- a/src/gamepad/mod.rs
+++ b/src/gamepad/mod.rs
@@ -1,6 +1,8 @@
 use bevy::prelude::*;
 use bevy::input::gamepad::{GamepadConnection, GamepadConnectionEvent};
 
+use crate::player::PlayerShip;
+
 pub struct GamepadPlugin;
 
 impl Plugin for GamepadPlugin {
@@ -34,18 +36,18 @@ fn gamepad_connections(
                     }
                 }
             }
-            // other events are irrelevant
-            _ => {}
+            _ => {}  // Discard anything else
         }
     }
 }
 
 fn gamepad_input(
     axes: Res<Axis<GamepadAxis>>,
-    buttons: Res<Input<GamepadButton>>,
+    buttons: Res<ButtonInput<GamepadButton>>,
     my_gamepad: Option<Res<MyGamepad>>,
-    mut query: Query<&mut Transform, With<PirateShip>>,
+    mut query: Query<&mut PlayerShip>,
 ) {
+    let mut ship = query.single_mut();
     let gamepad = if let Some(gp) = my_gamepad {
         gp.0
     } else {
@@ -63,8 +65,9 @@ fn gamepad_input(
     if let (Some(x), Some(y)) = (axes.get(axis_lx), axes.get(axis_ly)) {
         let left_stick_pos = Vec2::new(x, y);
 
-        if left_stick_pos.length() > 0.9 && left_stick_pos.y != 0. && left_stick_pos.x != 0. {
-            info!("{:?} x: {} y: {}", gamepad, left_stick_pos.x, left_stick_pos.y);
+        ship.velocity = left_stick_pos;
+        if ship.velocity.x != 0. && ship.velocity.y != 0. {
+            info!(" x: {} y: {}", ship.velocity.x, ship.velocity.y);
         }
     }
 
@@ -73,6 +76,6 @@ fn gamepad_input(
     };
 
     if buttons.just_pressed(sails_button) {
-        
+        info!("Argggg! Sails be toggled!");
     }
 }

--- a/src/gamepad/mod.rs
+++ b/src/gamepad/mod.rs
@@ -1,0 +1,78 @@
+use bevy::prelude::*;
+use bevy::input::gamepad::{GamepadConnection, GamepadConnectionEvent};
+
+pub struct GamepadPlugin;
+
+impl Plugin for GamepadPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, (gamepad_connections, gamepad_input));
+    }
+}
+
+#[derive(Resource)]
+pub struct MyGamepad(Gamepad);
+
+fn gamepad_connections(
+    mut commands: Commands,
+    my_gamepad: Option<Res<MyGamepad>>,
+    mut gamepad_evr: EventReader<GamepadConnectionEvent>,
+) {
+    for ev in gamepad_evr.read() {
+        let id = ev.gamepad;
+        match &ev.connection {
+            GamepadConnection::Connected(info) => {
+                info!("New gamepad connected with ID: {:?}, name: {}", id, info.name);
+                if my_gamepad.is_none() {
+                    commands.insert_resource(MyGamepad(id));
+                }
+            }
+            GamepadConnection::Disconnected => {
+                info!("Lost gamepad connection with ID: {:?}", id);
+                if let Some(MyGamepad(old_id)) = my_gamepad.as_deref() {
+                    if *old_id == id {
+                        commands.remove_resource::<MyGamepad>();
+                    }
+                }
+            }
+            // other events are irrelevant
+            _ => {}
+        }
+    }
+}
+
+fn gamepad_input(
+    axes: Res<Axis<GamepadAxis>>,
+    buttons: Res<Input<GamepadButton>>,
+    my_gamepad: Option<Res<MyGamepad>>,
+    mut query: Query<&mut Transform, With<PirateShip>>,
+) {
+    let gamepad = if let Some(gp) = my_gamepad {
+        gp.0
+    } else {
+        info!("No gamepad connected");
+        return;
+    };
+
+    let axis_lx = GamepadAxis {
+        gamepad, axis_type: GamepadAxisType::LeftStickX
+    };
+    let axis_ly = GamepadAxis {
+        gamepad, axis_type: GamepadAxisType::LeftStickY
+    };
+
+    if let (Some(x), Some(y)) = (axes.get(axis_lx), axes.get(axis_ly)) {
+        let left_stick_pos = Vec2::new(x, y);
+
+        if left_stick_pos.length() > 0.9 && left_stick_pos.y != 0. && left_stick_pos.x != 0. {
+            info!("{:?} x: {} y: {}", gamepad, left_stick_pos.x, left_stick_pos.y);
+        }
+    }
+
+    let sails_button = GamepadButton {
+        gamepad, button_type: GamepadButtonType::South
+    };
+
+    if buttons.just_pressed(sails_button) {
+        
+    }
+}

--- a/src/gamepad/mod.rs
+++ b/src/gamepad/mod.rs
@@ -1,6 +1,8 @@
 use bevy::prelude::*;
 use bevy::input::gamepad::{GamepadConnection, GamepadConnectionEvent};
 
+use crate::player::PlayerShip;
+
 pub struct GamepadPlugin;
 
 impl Plugin for GamepadPlugin {
@@ -34,18 +36,18 @@ fn gamepad_connections(
                     }
                 }
             }
-            // other events are irrelevant
-            _ => {}
+            _ => {}  // Discard anything else
         }
     }
 }
 
 fn gamepad_input(
     axes: Res<Axis<GamepadAxis>>,
-    buttons: Res<Input<GamepadButton>>,
+    buttons: Res<ButtonInput<GamepadButton>>,
     my_gamepad: Option<Res<MyGamepad>>,
-    mut query: Query<&mut Transform, With<PirateShip>>,
+    mut query: Query<&mut PlayerShip>,
 ) {
+    let mut ship = query.single_mut();
     let gamepad = if let Some(gp) = my_gamepad {
         gp.0
     } else {
@@ -63,8 +65,9 @@ fn gamepad_input(
     if let (Some(x), Some(y)) = (axes.get(axis_lx), axes.get(axis_ly)) {
         let left_stick_pos = Vec2::new(x, y);
 
-        if left_stick_pos.length() > 0.9 && left_stick_pos.y != 0. && left_stick_pos.x != 0. {
-            info!("{:?} x: {} y: {}", gamepad, left_stick_pos.x, left_stick_pos.y);
+        ship.velocity = left_stick_pos;
+        if ship.velocity.x != 0. && ship.velocity.y != 0. {
+            info!(" x: {} y: {}", ship.velocity.x, ship.velocity.y);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,14 @@
 mod worldgen;
 use worldgen::WorldGenPlugin;
 
+mod player;
+use player::PlayerPlugin;
+
 use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins, WorldGenPlugin))
+        .add_plugins((DefaultPlugins, WorldGenPlugin, PlayerPlugin))
         .add_systems(Startup, setup)
         .add_systems(Update, camera)
         .run();

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,11 +9,14 @@ use worldgen::WorldGenPlugin;
 mod player;
 use player::PlayerPlugin;
 
+mod gamepad;
+use gamepad::GamepadPlugin;
+
 use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins, WorldGenPlugin, PlayerPlugin))
+        .add_plugins((DefaultPlugins, WorldGenPlugin, PlayerPlugin, GamepadPlugin))
         .add_systems(Startup, setup)
         .add_systems(Update, camera)
         .run();

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -4,13 +4,14 @@ pub struct PlayerPlugin;
 
 impl Plugin for PlayerPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Startup, spawn_player);
+        app.add_systems(Startup, spawn_player)
+            .add_systems(Update, move_player);
     }
 }
 
 #[derive(Component)]
 pub struct PlayerShip {
-    pub velocity: Vec3,
+    pub velocity: Vec2,
 }
 
 fn spawn_player(
@@ -26,7 +27,25 @@ fn spawn_player(
             ..default()
         },
         PlayerShip{
-            velocity: Vec3::ZERO,
+            velocity: Vec2::ZERO,
         }
     ));
+}
+
+const MOVEMENT_SCALE: f32 = 25.;
+
+fn move_player(
+    mut ships: Query<(&mut Transform, &PlayerShip)>,
+    time: Res<Time>,
+) {
+    for (mut transform, ship) in &mut ships {
+        let movement = (ship.velocity * MOVEMENT_SCALE) * time.delta_seconds();
+        if ship.velocity.x < 0.0 {
+            transform.scale.x = transform.scale.x.abs() * -1.;
+        } else if ship.velocity.x > 0.0 {
+            transform.scale.x = transform.scale.x.abs();
+        }
+        transform.translation.x += movement.x;
+        transform.translation.y += movement.y;
+    }
 }

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -1,0 +1,32 @@
+use bevy::prelude::*;
+
+pub struct PlayerPlugin;
+
+impl Plugin for PlayerPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, spawn_player);
+    }
+}
+
+#[derive(Component)]
+pub struct PlayerShip {
+    pub velocity: Vec3,
+}
+
+fn spawn_player(
+    mut commands: Commands,
+    assets: Res<AssetServer>
+) {
+    let sprite_size = Vec2::new(32.0, 32.0);
+    commands.spawn((
+        SpriteBundle {
+            texture: assets.load("ducky.png"),
+            transform: Transform::from_scale(
+                Vec3::new(sprite_size.x / 200., sprite_size.y / 225., 1.)),
+            ..default()
+        },
+        PlayerShip{
+            velocity: Vec3::ZERO,
+        }
+    ));
+}

--- a/src/worldgen/mod.rs
+++ b/src/worldgen/mod.rs
@@ -144,7 +144,7 @@ fn spawn_chunks(
                     cmd.spawn(MapBundleManaged::new(chunk, mat.as_mut()))
                         .insert(Chunk)
                         .insert(Transform {
-                            translation: Vec3::new(pos.x, pos.y, 0.),
+                            translation: Vec3::new(pos.x, pos.y, -1.),
                             ..default()
                         })
                         .id(),


### PR DESCRIPTION
This change adds a player to the game that is controlled using the left analog stick of the connected gamepad. It creates the Components used to represent the main player (`PlayerShip`), creates the Gamepad input handling, and ties them together to move the sprite.

I ran into an issue where _sometimes_ the sprite would spawn below the map, so I reduced the map's z value to -1 and the sprite to 1. This seems to have fixed the issue, but let me know if there are any other considerations there.

I would appreciate any feedback here, I am really new to Rust and Bevy so really have no clue wtf I am doing lol